### PR TITLE
HOTFIX/eslint-rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
   "rules": {
     "react/prop-types": 2,
     "react/react-in-jsx-scope": 0,
+    "react-hooks/exhaustive-deps": 0,
     "prettier/prettier": 1
   },
   "settings": {


### PR DESCRIPTION
-added exception for eslint to not throw Warning when dependency array is empty