### PR TITLE
 Fix | 1 | Exercise score screen - text when putting score #280 

### DIFF
--- a/src/Atoms/Exercise/ExerciseStyled.js
+++ b/src/Atoms/Exercise/ExerciseStyled.js
@@ -15,7 +15,7 @@ const ExerciseStyled = styled(ExerciseCardStyled)`
       ? `background-color: ${props.theme.positive200};`
       : `background-color:  ${props.theme.grey100}; 
       color: ${props.theme.grey400}
-      `}
+      `};
   text-align: left;
 `;
 


### PR DESCRIPTION
Fixed /1/ Text of exercise when entering score is no longer justified to the center.
![obraz](https://user-images.githubusercontent.com/96307488/154260355-1207a886-8933-41e1-ba08-ddbdece75152.png)


TODO: Footer jumping above virtual keyboard will be fixed in the next part.